### PR TITLE
passes db pfile description to pf.load_data()

### DIFF
--- a/nimsproc/processor.py
+++ b/nimsproc/processor.py
@@ -435,7 +435,11 @@ class PFilePipeline(Pipeline):
                 log.debug('no special criteria')
                 aux_file = None
 
-            pf.load_data(aux_file=aux_file)  # don't monopolize system resources
+            # provide aux_files and db_description to pfile.load_data.  aux_file will be used for calibration scan,
+            # db_desc passes the database description to the pfile.load_data fxn, allowing pfile.load_data() to
+            # make additional decisions based on the description stored in the database.
+            # This allows user-edits to the description to affect jobs.
+            pf.load_data(aux_file=aux_file, db_desc=self.job.data_container.description)
             if pf.failure_reason:   # implies pf.data = None
                 self.job.activity = (u'error loading pfile: %s' % str(pf.failure_reason))
                 transaction.commit()


### PR DESCRIPTION
The pfile processor will pass the current pfile's series description to the pfile.load_data() fxn.

This change relies on updates to the following:
- cni/nimsdata, to allow pfile.load_data() to accept kwarg 'db_desc'.
- cni/mux_epi_recon to deal with a new option.

This is a somewhat tricky change, as it requires changes at three different levels.  One change here in the processor level, to pass the db description to nimspfile (this PR).  One change in nimspfile, to parse the db_desc to toggle a special option in the octave command (cni/nimsdata#2).  One change in the mux_epi_recon code, to handle the new option.